### PR TITLE
Add city pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem "puma", ">= 5.0"
 # Dotenv
 gem "dotenv-rails"
 
+gem 'kaminari'
+
 gem "activerecord-import"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,18 @@ GEM
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     logger (1.6.6)
@@ -323,6 +335,7 @@ DEPENDENCIES
   debug
   dotenv-rails
   kamal
+  kaminari
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 8.0.1)

--- a/app/controllers/api/v1/cities_controller.rb
+++ b/app/controllers/api/v1/cities_controller.rb
@@ -1,13 +1,28 @@
 class Api::V1::CitiesController < ApplicationController
+  include ApiResponder
   
   # GET /api/v1/cities
   def index
-    # Check if request has limit parameter
-    per_page = params[:limit].present? ? params[:limit].to_i : 10
-    per_page = 50 if per_page > 50
-
-    @cities = City.page(params[:page]).per(per_page)
-      .order(name: :ASC, country_code: :ASC)
-    render json: @cities
+    begin
+      total_count = City.count
+      # Check if request has limit parameter
+      per_page = params[:limit].present? ? params[:limit].to_i : 10
+      per_page = 50 if per_page > 50
+      
+      total_pages = (total_count / per_page).ceil
+      
+      @cities = City.page(params[:page]).per(per_page)
+        .order(name: :ASC, country_code: :ASC)
+      success data: {
+        data: @cities,
+        meta: {
+          current_page: params[:page].present? ? params[:page].to_i : 1,
+          total_count: total_count,
+          total_pages: total_pages,
+        }
+      }
+    rescue => e
+      error(message: e.message)
+    end
   end
 end

--- a/app/controllers/api/v1/cities_controller.rb
+++ b/app/controllers/api/v1/cities_controller.rb
@@ -2,7 +2,12 @@ class Api::V1::CitiesController < ApplicationController
   
   # GET /api/v1/cities
   def index
-    @cities = City.order(name: :ASC, country_code: :ASC)
+    # Check if request has limit parameter
+    per_page = params[:limit].present? ? params[:limit].to_i : 10
+    per_page = 50 if per_page > 50
+
+    @cities = City.page(params[:page]).per(per_page)
+      .order(name: :ASC, country_code: :ASC)
     render json: @cities
   end
 end

--- a/app/controllers/concerns/api_responder.rb
+++ b/app/controllers/concerns/api_responder.rb
@@ -1,7 +1,7 @@
 module ApiResponder
   extend ActiveSupport::Concern
 
-  def success(data= nil, message: nil, code: 200)
+  def success(data: nil, message: nil, code: 200)
     render json: {
       status: 'success',
       message: message,
@@ -15,3 +15,4 @@ module ApiResponder
       message: message
     }, status: code
   end
+end

--- a/app/controllers/concerns/api_responder.rb
+++ b/app/controllers/concerns/api_responder.rb
@@ -1,0 +1,17 @@
+module ApiResponder
+  extend ActiveSupport::Concern
+
+  def success(data= nil, message: nil, code: 200)
+    render json: {
+      status: 'success',
+      message: message,
+      data: data
+    }, status: code
+  end
+
+  def error(message: nil, code: 500)
+    render json: {
+      status: 'error',
+      message: message
+    }, status: code
+  end


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Add pagination lib ⚡️`kaminari`⚡️
- Add a `Concern` module, a reusable of success (RESPOND CODE of `200`, by default) and error method in the API controllers

## What is the current behavior?

- None of the mentioned features exist

## What is the new behavior?

- This is a great demonstration of pagination for an over 200-thousand-record-table to split the records into smaller chunks
- Add an abstract layer while remain the consistency for the responses thorough the controllers

## Additional context

*Not available*
